### PR TITLE
Adds README document

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+---
+id: README.md
+title: Hubs Foundation GitHub general repository
+---
+# Hubs Foundation GitHub General Repository
+
+This repository contains documentation for the general use of all Hubs Foundation GitHub repositories. Hubs Foundation uses GitHub repositories (60 of them, whew!), in part, for the discussion, contribution management, and feedback of the Hubs software as well as many aspects of operating an open-source non-profit webXR organization. Using GitHub in this way allows for healthy documentation of contributions, alternative viewpoints, and a detailed depth of history. We welcome the community to help us build a better organization.
+
+Contributions to this repository are expected to be:
+- of a general, overarching nature
+- aligned with the Hubs Foundation Principles and Values
+- professional in tone.
+
+The documentation is under active development. If there are any changes or updates you recommend, feel free to submit a pull request or let us know in our [Discord Server](https://discord.gg/wHmY4nd).
+
+If you are new to GitHub, we are building training documentation to help you! Stay tuned.
+
+This repository is maintained by the Hubs Foundation.


### PR DESCRIPTION
## What?
Adds README document for the .github repository. Includes why HF uses GitHub. 3 general expectations. How to contribute and that HF is responsible.

## Why?
Repository did not have an initial README

## Limitations
None

## Alternatives considered
Could keep swimming with no README but then this repository would look pointless.


## Open questions

1. I could not remember our official name for our Principles and Values (and would possibly like to add a link to those if they are link-able). 
2. Fact check the number of repositories. 
3. Should I add any reference to the responsibility of the Communication & Documentation Team _within_ HF, rather than just HF, or is that making this repository seem a tad more unnecessarily exclusive?


## Additional details or related context
Forgive commit typos. 
Comments welcome.

Used this reference from GitHub Followed [this guidance](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes):

A README is often the first item a visitor will see when visiting your repository. README files typically include information on:
- What the project does
- Why the project is useful
- How users can get started with the project
- Where users can get help with your project
- Who maintains and contributes to the project

