### PR TITLE
Add a roadmap auto commenter for use by all repositories

### DIFF
--- a/.github/workflows/reusable-roadmap-auto-commenter.yml
+++ b/.github/workflows/reusable-roadmap-auto-commenter.yml
@@ -1,3 +1,5 @@
+# WARNING: This workflow is sometimes triggered by pull_request_target and so will always run automatically on pull requests made by anyone.  Do not do any sort of processing of user input, such as checking out code.
+
 name: Reusable Roadmap Auto Commenter
 on:
   workflow_call
@@ -27,7 +29,7 @@ jobs:
             For more information on how the roadmaps work, see our [roadmaps policy on GitHub](https://github.com/Hubs-Foundation/policies-procedures-guidelines-public/blob/main/roadmaps-policy.md).
 
   add_pull_request_comment:
-    if: ${{ github.event_name == 'pull_request' && github.repository_owner == 'Hubs-Foundation' }}
+    if: ${{ github.event_name == 'pull_request_target' && github.repository_owner == 'Hubs-Foundation' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/reusable-roadmap-auto-commenter.yml
+++ b/.github/workflows/reusable-roadmap-auto-commenter.yml
@@ -1,0 +1,50 @@
+name: Reusable Roadmap Auto Commenter
+on:
+  workflow_call
+
+jobs:
+  add_issue_comment:
+    if: ${{ github.event_name == 'issues' && github.repository_owner == 'Hubs-Foundation' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: add initial issue comment
+        if: "${{ !contains(join(github.event.issue.labels.*.name), 'Roadmap:') }}"
+        run: |
+          gh issue comment "$NUMBER" --body "$BODY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.issue.number }}
+          BODY: |
+            Thank you for the issue.
+
+            ROADMAP STATUS: This issue isn't currently on any roadmap.  Updates will be conveyed here as its place on/off a roadmap changes.
+
+            You can view the roadmaps here: [Roadmaps Google Drive folder](https://drive.google.com/drive/folders/1Z6q2GoqnXIslxfcPP0ctVlTAKLi9OzEt).
+
+            For more information on how the roadmaps work, see our [roadmaps policy on GitHub](https://github.com/Hubs-Foundation/policies-procedures-guidelines-public/blob/main/roadmaps-policy.md).
+
+  add_pull_request_comment:
+    if: ${{ github.event_name == 'pull_request' && github.repository_owner == 'Hubs-Foundation' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: add initial pull request comment
+        if: "${{ !contains(join(github.event.pull_request.labels.*.name), 'Roadmap:') }}"
+        run: |
+          gh pr comment "$NUMBER" --body "$BODY"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ github.event.number }}
+          BODY: |
+            Thank you for the pull request.
+
+            ROADMAP STATUS: This pull request isn't currently on any roadmap.  Updates will be conveyed here as its place on/off a roadmap changes.
+
+            You can view the roadmaps here: [Roadmaps Google Drive folder](https://drive.google.com/drive/folders/1Z6q2GoqnXIslxfcPP0ctVlTAKLi9OzEt).
+
+            For more information on how the roadmaps work, see our [roadmaps policy on GitHub](https://github.com/Hubs-Foundation/policies-procedures-guidelines-public/blob/main/roadmaps-policy.md).


### PR DESCRIPTION
## What?
<!-- REQUIRED — Explain what your pull request does -->
Adds a workflow that will leave a comment on newly opened issues and pull requests about the roadmap status (i.e. that it isn't on any roadmap yet) of that issue/pull request that can be called by any Hubs Foundation repository.

## Why?
<!-- REQUIRED — Explain why you're opening this pull request, what limitations does it address, etc..  If you're fixing a bug with an open bug report you can just link to the bug report -->
So that people will know what to expect and so that someone doesn't have to manually respond to new issues/pull requests with a stock reply.  Also, it's added as a reusable workflow so that changes to the comments or behaviour only have to be made to this workflow, rather than the workflow in every repository.

## Examples
<!-- OPTIONAL — If applicable, give examples of the changes the user will observe, e.g. screenshots, videos, diagrams, console output, etc., otherwise put "N/A" or remove the section.  Including examples of before the PR and after the PR is encouraged. -->
Comment on a newly opened issue:
<img width="938" height="297" alt="2026-05-04_01-55" src="https://github.com/user-attachments/assets/691cfbec-eac6-4f93-8d83-b70523afaff7" />

Comment on a newly opened pull request:
<img width="889" height="299" alt="2026-05-04_02-05" src="https://github.com/user-attachments/assets/13f04242-1ac9-4964-97fb-d17578f50044" />


## How to test
<!-- REQUIRED — Give the steps required to test your pull request -->

1. Add this to to the default branch of one of your repositories (with the guard limiting it to only run on Hubs Foundation repositories removed).
2. Add a caller workflow (based on: [#12](https://github.com/Hubs-Foundation/.github/pull/12)) to your repository (change the path to point to your version of the reusable workflow).
3. Open an issue and a pull request (without a roadmap label).
4. See that the issue and pull request each have a comment added to them indicating they're not on a roadmap yet.
5. Open an issue and a pull request (with a roadmap label, e.g. `Roadmap: Test`).
6. See that no comment is added to the issue or pull request.

## Documentation of functionality
<!-- REQUIRED — Link to the accompanying documentation pull request or identify where the documentation is located in this pull request.  If no documentation is needed, please specify this here -->
Currently, this is fully automatic with no configuration options and it is for the Hubs Foundation's use only (so not appropriate to put in the Hubs Docs).  This helps to apply the roadmap policy.  In light of all this, I don't think any additional documentation is needed at present.

## Limitations
<!-- OPTIONAL — If there is anything you decided not to do/support in this PR that might otherwise be expected, list them here along with the reason why you didn't do/support them, otherwise put "None" -->
None known.

## Alternative implementations considered
<!-- OPTIONAL — If there are any alternative ways of implementing this change that you thought of, but decided against, list them here along with why they were discarded, otherwise put "None" -->
None.

## Open questions
<!-- OPTIONAL — If you have any questions, put them here, otherwise put "None" -->
None.

## Additional details or related context
<!-- OPTIONAL — If there are any other details that you think the reviewers should be aware of that you didn't put elsewhere, e.g. links to related issues, pull requests, references you used, notes on weird things, attribution, etc., put them here, otherwise put "None" -->
This won't add a comment if it finds a roadmap label has been added to the issue/pull request during creation.

Roadmap policy PR: https://github.com/Hubs-Foundation/policies-procedures-guidelines-public/pull/25

This workflow will need a caller workflow added to each repository.
Initial companion PR to call this workflow: https://github.com/Hubs-Foundation/.github/pull/12

Note: this is only intended to help convey our use of roadmaps and the status of an issue/PR on them (by providing one way notifications).  It is not intended for this to expand into any sort of customer service auto-responder that would reply to all comments or that could be interacted with by people.